### PR TITLE
Improved loading of logs in Details tab

### DIFF
--- a/app/assets/javascripts/rsnapshot_backups.js
+++ b/app/assets/javascripts/rsnapshot_backups.js
@@ -1,3 +1,4 @@
+
 $(document).on('click', '.open-backup-destination-path', function(event) {
 	var current = event.target;
 	current.style.display = "none";
@@ -277,3 +278,58 @@ $(document).on('ajax:success', '#update_interval_form_id', function(event, resul
     }
 });
 
+function getLogElement(log){
+    var node = document.createElement('div');
+    var count = document.getElementsByClassName("log-details").length;
+
+    var alert_type = "alert-warning";
+    if(log["end_message"].indexOf("completed successfully")!=-1){
+        alert_type = "alert-success";
+    }
+    if(log["end_message"].indexOf("error")!=-1 || log["end_message"].indexOf("ERROR")!=-1){
+        alert_type = "alert-danger";
+    }
+
+    node.innerHTML = "<span class='text-underline h5'>Backup # "+(count+1)+"</span> <br> <div class='alert "+alert_type+" mt-2 log-details' role='alert'><span>Started at: "+log["start_time"]+"</span><span class='text-capitalize float-right'>Type: "+log["type"]+"</span><br><span>Finished at: "+log["end_time"]+"</span><span class='text-capitalize float-right'>Status: "+log["end_message"]+"</span><br></div>";
+    return node;
+}
+
+$(document).on('click', '#load_more_btn', function(event) {
+    var element = event.target.parentElement;
+    var next = element.nextSibling;
+
+    if(element){
+        element.style.display = "none";
+    }
+    if(next){
+        next.style.display = "";
+    }
+
+    var value = document.getElementById("skip_lines_span").innerHTML;
+
+    $.get("/tab/amahi_backups/next_entries?skip_lines="+value, function(data, status){
+        if(element){
+            element.style.display = "";
+        }
+        if(next){
+            next.style.display = "none";
+        }
+
+        if(status=="success"){
+            document.getElementById("skip_lines_span").innerHTML = data["skip_lines"];
+
+            if(data["logs"].length<10){
+                element.style.display = "none";
+            }
+
+            for(var k=0;k<data["logs"].length;k++){
+                var log_element = getLogElement(data["logs"][k]);
+
+                for(var j=0; j<log_element.childNodes.length; j++){
+                    element.parentElement.parentElement.insertBefore(log_element.childNodes[j], element.parentElement.parentElement.children[element.parentElement.parentElement.children.length-1]);
+                }
+
+            }
+        }
+    });
+});

--- a/app/controllers/rsnapshot_backups_controller.rb
+++ b/app/controllers/rsnapshot_backups_controller.rb
@@ -10,7 +10,16 @@ class RsnapshotBackupsController < ApplicationController
 		RsnapshotHelper.run_init_script if RsnapshotHelper.first_time_setup
 		@cron_job_status = CronTabHelper.check_status
 		@dest_path = RsnapshotHelper.get_fields("snapshot_root")
-		@logs = @cron_job_status? RsnapshotLogUtil.get_log_output : nil
+		@logs, @skip_lines = @cron_job_status? RsnapshotLogUtil.get_last_entries : nil
+	end
+
+	def get_next_entries
+		unless params[:skip_lines].blank?
+			logs, skip_lines = RsnapshotLogUtil.get_last_entries(params[:skip_lines])
+			render :json => {success: true, logs: logs, skip_lines: skip_lines}
+		else
+			render :json => {success: false, message: "Error: params missing"}
+		end
 	end
 
 	def settings

--- a/app/views/rsnapshot_backups/index.html.slim
+++ b/app/views/rsnapshot_backups/index.html.slim
@@ -20,7 +20,7 @@
           - alert_type = "alert-success" if !(log[:end_message].blank?) and !(log[:end_message].index("completed successfully").nil?)
           - alert_type = "alert-danger" if !(log[:end_message].blank?) and (!(log[:end_message].index("error").nil?) or !(log[:end_message].index("ERROR").nil?))
 
-          div class="alert #{alert_type} mt-2" role="alert"
+          div class="alert #{alert_type} mt-2 log-details" role="alert"
             span = "Started at: #{log[:start_time]}"
             span.text-capitalize.float-right = "Type: #{log[:type]}"
             br
@@ -36,8 +36,12 @@
             br
 
     .loading-div.pl-3.pr-3
+      span#skip_lines_span.d-none = "#{@skip_lines}"
       .load-more
-        input type="button" style="display:flex; margin: 0 auto; cursor: pointer;" value="Load More..."
+        input#load_more_btn type="button" style="display:flex; margin: 0 auto; cursor: pointer;" value="Load More..."
       .progress style="display: none;"
         .progress-bar.progress-bar-striped.progress-bar-animated.bg-info aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" role="progressbar" style="width: 100%"
-          span Loading more...
+          span 
+            = "Loading more..."
+
+= javascript_include_tag 'rsnapshot_backups'

--- a/app/views/rsnapshot_backups/index.html.slim
+++ b/app/views/rsnapshot_backups/index.html.slim
@@ -34,3 +34,10 @@
             - else
               span.text-capitalize.float-right = "Status: #{log[:end_message]}"
             br
+
+    .loading-div.pl-3.pr-3
+      .load-more
+        input type="button" style="display:flex; margin: 0 auto; cursor: pointer;" value="Load More..."
+      .progress style="display: none;"
+        .progress-bar.progress-bar-striped.progress-bar-animated.bg-info aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" role="progressbar" style="width: 100%"
+          span Loading more...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ RsnapshotBackups::Engine.routes.draw do
 	post 'start_backups' => 'rsnapshot_backups#start_backups'
 	post 'stop_backups' => 'rsnapshot_backups#stop_backups'
 	post 'update_interval' => 'rsnapshot_backups#update_interval'
+	get 'next_entries' => 'rsnapshot_backups#get_next_entries'
 end

--- a/lib/rsnapshot_backups/rsnapshot_log_util.rb
+++ b/lib/rsnapshot_backups/rsnapshot_log_util.rb
@@ -74,10 +74,15 @@ class RsnapshotLogUtil
 			log_enteries = []
 			return log_enteries unless File.exists?(get_log_file_path)
 
+			from_line = from_line.to_i
 			skip_lines = 0
 
 			Elif.open(get_log_file_path, "r").each do |line|
-				skip_lines = skip_lines+1
+				skip_lines = skip_lines + 1
+
+				unless from_line.blank?
+					next if skip_lines <= from_line
+				end
 
 				line.gsub!("WARNING: ","")
 				if line =~ /\[.*\] \/bin\/rsnapshot (daily|weekly|monthly): .*/

--- a/lib/rsnapshot_backups/rsnapshot_log_util.rb
+++ b/lib/rsnapshot_backups/rsnapshot_log_util.rb
@@ -1,4 +1,5 @@
 require "date"
+require "elif"
 require "rsnapshot_backups/rsnapshot_helper.rb"
 include ActionView::Helpers::DateHelper
 
@@ -67,6 +68,61 @@ class RsnapshotLogUtil
 		def get_log_output
 			log_enteries = self.parse_log_file
 			return log_enteries.reverse
+		end
+
+		def get_last_entries(from_line = nil)
+			log_enteries = []
+			return log_enteries unless File.exists?(get_log_file_path)
+
+			skip_lines = 0
+
+			Elif.open(get_log_file_path, "r").each do |line|
+				skip_lines = skip_lines+1
+
+				line.gsub!("WARNING: ","")
+				if line =~ /\[.*\] \/bin\/rsnapshot (daily|weekly|monthly): .*/
+
+					unless line.index("started").nil?
+						type = nil
+						start_message = nil
+						if !(line.index("daily").nil?)
+							type = "daily"
+							start_message = line[44..-1].strip
+						elsif !(line.index("weekly").nil?)
+							type = "weekly"
+							start_message = line[45..-1].strip
+						elsif !(line.index("monthly").nil?)
+							type = "monthly"
+							start_message = line[46..-1].strip
+						end
+
+						last_entry = log_enteries.last
+						last_entry[:start_time] = parse_datetime_string(line[1..19])
+						last_entry[:type] = type
+						last_entry[:start_message] = start_message
+						log_enteries.pop()
+						log_enteries << last_entry
+
+						break if log_enteries.size == 10
+
+					else
+						end_message = nil
+						if !(line.index("daily").nil?)
+							end_message = line[44..-1].strip
+						elsif !(line.index("weekly").nil?)
+							end_message = line[45..-1].strip
+						elsif !(line.index("monthly").nil?)
+							end_message = line[46..-1].strip
+						end
+
+						log_enteries << {end_time: parse_datetime_string(line[1..19]), end_message: end_message}
+
+					end
+				end
+
+			end
+
+			return log_enteries, skip_lines
 		end
 
 	end


### PR DESCRIPTION
Used "elif" gem for reading the large log file from bottom to top.
Also we must add "perl-Lchown.x86_64" dependency for this plugin so that lots of warning messages like "WARNING: Could not lchown()" can be eliminated from log file and thus file can be made smaller in size.